### PR TITLE
Feature/windows terminal launcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ json = "*"
 md5 = "*"
 num_cpus = "*"
 reqwest = "*"
+# Fixed HJSON version, because of failed parsing of HJSON on latest version
+# https://github.com/hjson/hjson-rust/issues/23#issuecomment-775520018
+serde-hjson = { version = "0.9", default-features = false }
 tokio = { version = "1", features = ["full"] }
 walkdir = "*"
 wmi = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idf_env"
-version = "1.1.6"
+version = "1.1.7"
 authors = ["Juraj Michalek <juraj.michalek@espressif.com>"]
 edition = "2018"
 
@@ -13,9 +13,6 @@ json = "*"
 md5 = "*"
 num_cpus = "*"
 reqwest = "*"
-# Fixed HJSON version, because of failed parsing of HJSON on latest version
-# https://github.com/hjson/hjson-rust/issues/23#issuecomment-775520018
-serde-hjson = { version = "0.9", default-features = false }
 tokio = { version = "1", features = ["full"] }
 walkdir = "*"
 wmi = "*"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ idf-env config edit
 idf-env config rm id
 ```
 
-### Working with installations of ESP-IDF
+### Working with launchers of ESP-IDF
 ```
+idf-env launcher add --shell powershell --to windows-terminal
+idf-env launcher add --shell powershell --to desktop
+idf-env launcher add --shell cmd --to startmenu
+idf-env launcher add --shell powershell --to windows-terminal --title "ESP-IDF v4.4" --idf-path "C:/esp/"
+```
+
+### Working with installations of ESP-IDF
+``` 
 idf-env idf install
 idf-env idf install --idf-version "master" --installer "G:\idf-installer\build\esp-idf-tools-setup-online-unsigned.exe"
 idf-env idf uninstall

--- a/README.md
+++ b/README.md
@@ -27,10 +27,7 @@ idf-env config rm id
 
 ### Working with launchers of ESP-IDF
 ```
-idf-env launcher add --shell powershell --to windows-terminal
-idf-env launcher add --shell powershell --to desktop
-idf-env launcher add --shell cmd --to startmenu
-idf-env launcher add --shell powershell --to windows-terminal --title "ESP-IDF v4.4" --idf-path "C:/esp/"
+idf-env launcher add --shell powershell --to windows-terminal --title "ESP-IDF 4.4" --idf-path "C:/esp/"
 ```
 
 ### Working with installations of ESP-IDF

--- a/src/idf_env.rs
+++ b/src/idf_env.rs
@@ -10,6 +10,7 @@ mod config;
 mod companion;
 mod driver;
 mod idf;
+mod launcher;
 mod package;
 mod shell;
 
@@ -28,6 +29,7 @@ async fn app() -> Result<()> {
         .add_cmd(config::get_multi_cmd())
         .add_cmd(driver::get_multi_cmd())
         .add_cmd(idf::get_multi_cmd())
+        .add_cmd(launcher::get_multi_cmd())
         .no_cmd(|_args, _matches| {
             println!("No command matched. Use parameter --help");
             Ok(())

--- a/src/idf_env.rs
+++ b/src/idf_env.rs
@@ -17,7 +17,7 @@ mod shell;
 async fn app() -> Result<()> {
     Commander::new()
         .options(|app| {
-            app.version("1.1.6")
+            app.version("1.1.7")
                 .name("idf-env")
                 .author("Espressif Systems - https://www.espressif.com")
                 .about("Tool for maintaining ESP-IDF environment on computer.")

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -2,8 +2,6 @@ use clap::Arg;
 use clap_nested::{Command, Commander, MultiCommand};
 
 use std::{env, fs};
-use std::path::Path;
-
 use crate::config::get_tools_path;
 
 fn get_windows_terminal_fragments_path(title: &str) -> String {
@@ -19,7 +17,6 @@ fn get_add_runner(_args: &str, matches: &clap::ArgMatches<'_>) -> std::result::R
 
     // After fresh installation of Windows Terminal the fragment path does not exist.
     // Microsoft recommends to create one
-    // if !Path::new(&fragments_path).exists() {
     fs::create_dir_all(&fragments_path)?;
     let fragment_json_path = format!("{}/fragment.json", fragments_path);
     println!("Updating Windows Terminal Fragment: {}", fragment_json_path);

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,0 +1,91 @@
+use clap::Arg;
+use clap_nested::{Command, Commander, MultiCommand};
+
+use std::{env, fs};
+use std::path::Path;
+//#![feature(custom_derive, plugin)]
+//#![plugin(serde_macros)]
+extern crate serde_hjson;
+use serde_hjson::{Map,Value};
+
+
+fn get_json_path() -> String {
+    let local_app_data = env::var("LocalAppData").unwrap();
+    format!("{}/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json", local_app_data)
+}
+
+fn load_json() -> Result<String, String> {
+    let json_path = get_json_path();
+    println!("Loading configuration of Windows Terminal: {}", json_path);
+    if !Path::new(&json_path).exists() {
+        let result = Err(format!("Windows Terminal configuration not found: {}", json_path));
+        return result
+    }
+
+
+    let content = fs::read_to_string(json_path)
+        .expect("Failure");
+
+    let mut out: Value = serde_hjson::from_str(&content.to_string()).unwrap();
+    let sample2 = serde_hjson::to_string(&out).unwrap();
+    // let data: Value = serde_hjson::from_str("{foo: 13, bar: \"baz\"}").unwrap();
+    println!("{}", sample2);
+    Ok("Done".to_string())
+}
+
+fn get_add_runner(_args: &str, _matches: &clap::ArgMatches<'_>) -> std::result::Result<(), clap::Error> {
+    match load_json() {
+        Err(e) => { println!("{}", e); }
+        Ok(v) => { println!("ok") }
+    }
+    Ok(())
+}
+
+
+pub fn get_add_cmd<'a>() -> Command<'a, str> {
+    Command::new("add")
+        .description("Add ESP-IDF launcher")
+        .options(|app| {
+            app.arg(
+                Arg::with_name("shell")
+                    .short("s")
+                    .long("shell")
+                    .takes_value(true)
+                    .help("Shell which should be launched: powershell, cmd"),
+            )
+                .arg(
+                    Arg::with_name("to")
+                        .short("t")
+                        .long("to")
+                        .takes_value(true)
+                        .help("Where to add the launcher: desktop, start-menu, windows-terminal"),
+                )
+                .arg(
+                    Arg::with_name("title")
+                        .short("i")
+                        .long("title")
+                        .takes_value(true)
+                        .help("Title displayed on launcher"),
+                )
+                .arg(
+                    Arg::with_name("idf-path")
+                        .short("x")
+                        .long("idf-path")
+                        .takes_value(true)
+                        .help("Path to ESP-IDF"),
+                )
+        })
+        .runner(|_args, matches| get_add_runner(_args, matches)
+        )
+}
+
+pub fn get_multi_cmd<'a>() -> MultiCommand<'a, str, str> {
+    let multi_cmd: MultiCommand<str, str> = Commander::new()
+        .add_cmd(get_add_cmd())
+        .into_cmd("launcher")
+
+        // Optionally specify a description
+        .description("Manage ESP-IDF launchers.");
+
+    return multi_cmd;
+}

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -9,6 +9,11 @@ fn get_windows_terminal_fragments_path(title: &str) -> String {
     format!("{}/Microsoft/Windows Terminal/Fragments/{}", local_app_data, title)
 }
 
+fn get_powershell_path() -> String {
+    let windir = env::var("windir").unwrap();
+    format!("{}/System32/WindowsPowerShell/v1.0/powershell.exe", windir)
+}
+
 fn get_add_runner(_args: &str, matches: &clap::ArgMatches<'_>) -> std::result::Result<(), clap::Error> {
     let title = matches.value_of("title").unwrap();
     let idf_path = matches.value_of("idf-path").unwrap();
@@ -21,7 +26,7 @@ fn get_add_runner(_args: &str, matches: &clap::ArgMatches<'_>) -> std::result::R
     let fragment_json_path = format!("{}/fragment.json", fragments_path);
     println!("Updating Windows Terminal Fragment: {}", fragment_json_path);
 
-    let command_line = format!("C:/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe -ExecutionPolicy Bypass -NoExit -File {}/Initialize-Idf.ps1", tools_path);
+    let command_line = format!("{} -ExecutionPolicy Bypass -NoExit -File {}/Initialize-Idf.ps1", get_powershell_path(), tools_path);
 
     let profile_json = json::object! {
         "name": title,


### PR DESCRIPTION
New command which allows to register launcher for Windows terminal.
The registration is done via Windows Terminal Fragment JSON located in user's AppData.
The launcher assumes presence of ESP-IDF initializer for PowerShell.