### PR TITLE
tools: add support for config retrieval by idf-id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idf_env"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Juraj Michalek <juraj.michalek@espressif.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idf_env"
-version = "1.1.9"
+version = "1.2.0"
 authors = ["Juraj Michalek <juraj.michalek@espressif.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idf_env"
-version = "1.1.7"
+version = "1.1.9"
 authors = ["Juraj Michalek <juraj.michalek@espressif.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ File stored in esp_idf.json
 ```
 idf-env config get
 idf-env config get --property gitPath
+idf-env config get --property python --idf-id esp-idf-618cf3b908db7b2ed74540bde5ba6605
 idf-env config get --property python --idf-path "C:/esp/"
 idf-env config add --idf-version "v4.2" --idf-path "C:/esp/" --python "C:/python/python.exe"
 idf-env config add --name idf --idf-version "v4.2" --idf-path "C:/esp/" --python "C:/python/python.exe"

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,12 +10,6 @@ use dirs::home_dir;
 use json::JsonValue;
 use crate::shell::run_command;
 
-fn print_parent_path(property_path: &std::string::String) {
-    let path = Path::new(&property_path);
-    let parent = path.parent().unwrap().to_str();
-    print!("{}", parent.unwrap());
-}
-
 pub fn get_tools_path() -> String {
     env::var("IDF_TOOLS_PATH").unwrap_or_else(|e|
         home_dir().unwrap().display().to_string() + "/.espressif"
@@ -85,7 +79,7 @@ pub fn get_property(property_name: String) -> String {
 }
 
 fn print_property(property_name: String) {
-    print_parent_path(&get_property(property_name));
+    print!("{}", &get_property(property_name));
 }
 
 pub fn get_git_path() -> String {
@@ -105,11 +99,11 @@ pub fn get_property_with_path(property_name: String, idf_path: String) -> String
 }
 
 fn print_property_with_path(property_name: String, idf_path: String) {
-    print_parent_path(&get_property_with_path(property_name, idf_path));
+    print!("{}", get_property_with_path(property_name, idf_path));
 }
 
 fn print_property_with_id(property_name: String, idf_id: String) {
-    print!("{}", &get_property_with_idf_id(property_name, idf_id));
+    print!("{}", get_property_with_idf_id(property_name, idf_id));
 }
 
 pub fn update_property(property_name: String, property_value: String) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ fn get_json_path() -> String {
     return idf_json_path;
 }
 
-fn get_idf_id(idf_path: String) -> String {
+pub fn get_idf_id(idf_path: &str) -> String {
     let idf_path_with_slash = format!("{}", idf_path.replace("\\", "/"));
     let digest = md5::compute(idf_path_with_slash);
     return format!("esp-idf-{:x}", digest);
@@ -94,7 +94,7 @@ pub fn get_property_with_idf_id(property_name: String, idf_id: String) -> String
 
 pub fn get_property_with_path(property_name: String, idf_path: String) -> String {
     let parsed_json = load_json();
-    let idf_id = get_idf_id(idf_path);
+    let idf_id = get_idf_id(&idf_path);
     return parsed_json["idfInstalled"][idf_id][property_name].to_string();
 }
 
@@ -113,7 +113,7 @@ pub fn update_property(property_name: String, property_value: String) {
 }
 
 pub fn add_idf_config(idf_path: String, version: String, python_path: String) {
-    let idf_id = get_idf_id(idf_path.clone());
+    let idf_id = get_idf_id(&idf_path);
     let _data = json::object! {
         version: version,
         python: python_path,

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,7 @@ use dirs::home_dir;
 use json::JsonValue;
 use crate::shell::run_command;
 
-fn print_path(property_path: &std::string::String) {
+fn print_parent_path(property_path: &std::string::String) {
     let path = Path::new(&property_path);
     let parent = path.parent().unwrap().to_str();
     print!("{}", parent.unwrap());
@@ -85,7 +85,7 @@ pub fn get_property(property_name: String) -> String {
 }
 
 fn print_property(property_name: String) {
-    print_path(&get_property(property_name));
+    print_parent_path(&get_property(property_name));
 }
 
 pub fn get_git_path() -> String {
@@ -105,7 +105,11 @@ pub fn get_property_with_path(property_name: String, idf_path: String) -> String
 }
 
 fn print_property_with_path(property_name: String, idf_path: String) {
-    print_path(&get_property_with_path(property_name, idf_path));
+    print_parent_path(&get_property_with_path(property_name, idf_path));
+}
+
+fn print_property_with_id(property_name: String, idf_id: String) {
+    print!("{}", &get_property_with_idf_id(property_name, idf_id));
 }
 
 pub fn update_property(property_name: String, property_value: String) {
@@ -147,12 +151,22 @@ pub fn get_cmd<'a>() -> Command<'a, str> {
                         .help("Path to ESP-IDF")
                         .takes_value(true),
                 )
+                .arg(
+                    Arg::with_name("idf-id")
+                        .short("j")
+                        .long("idf-id")
+                        .help("ESP-IDF installation ID")
+                        .takes_value(true),
+                )
         })
         .runner(|_args, matches| {
             if matches.is_present("property") {
                 let property_name = matches.value_of("property").unwrap().to_string();
 
-                if matches.is_present("idf-path") {
+                if matches.is_present("idf-id") {
+                    let idf_id = matches.value_of("idf-id").unwrap().to_string();
+                    print_property_with_id(property_name, idf_id);
+                } else if matches.is_present("idf-path") {
                     let idf_path = matches.value_of("idf-path").unwrap().to_string();
                     print_property_with_path(property_name, idf_path);
                 } else {

--- a/src/idf_env.rs
+++ b/src/idf_env.rs
@@ -17,7 +17,7 @@ mod shell;
 async fn app() -> Result<()> {
     Commander::new()
         .options(|app| {
-            app.version("1.1.7")
+            app.version("1.1.9")
                 .name("idf-env")
                 .author("Espressif Systems - https://www.espressif.com")
                 .about("Tool for maintaining ESP-IDF environment on computer.")

--- a/src/idf_env.rs
+++ b/src/idf_env.rs
@@ -17,7 +17,7 @@ mod shell;
 async fn app() -> Result<()> {
     Commander::new()
         .options(|app| {
-            app.version("1.1.9")
+            app.version("1.2.0")
                 .name("idf-env")
                 .author("Espressif Systems - https://www.espressif.com")
                 .about("Tool for maintaining ESP-IDF environment on computer.")

--- a/src/idf_env.rs
+++ b/src/idf_env.rs
@@ -17,7 +17,7 @@ mod shell;
 async fn app() -> Result<()> {
     Commander::new()
         .options(|app| {
-            app.version("1.2.0")
+            app.version("1.2.1")
                 .name("idf-env")
                 .author("Espressif Systems - https://www.espressif.com")
                 .about("Tool for maintaining ESP-IDF environment on computer.")

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -2,7 +2,7 @@ use clap::Arg;
 use clap_nested::{Command, Commander, MultiCommand};
 
 use std::{env, fs};
-use crate::config::get_tools_path;
+use crate::config::{get_tools_path, get_idf_id};
 
 fn get_windows_terminal_fragments_path(title: &str) -> String {
     let local_app_data = env::var("LocalAppData").unwrap();
@@ -19,6 +19,7 @@ fn get_add_runner(_args: &str, matches: &clap::ArgMatches<'_>) -> std::result::R
     let idf_path = matches.value_of("idf-path").unwrap();
     let fragments_path = get_windows_terminal_fragments_path(title);
     let tools_path = get_tools_path();
+    let idf_id = get_idf_id(idf_path);
 
     // After fresh installation of Windows Terminal the fragment path does not exist.
     // Microsoft recommends to create one
@@ -26,7 +27,7 @@ fn get_add_runner(_args: &str, matches: &clap::ArgMatches<'_>) -> std::result::R
     let fragment_json_path = format!("{}/fragment.json", fragments_path);
     println!("Updating Windows Terminal Fragment: {}", fragment_json_path);
 
-    let command_line = format!("{} -ExecutionPolicy Bypass -NoExit -File {}/Initialize-Idf.ps1", get_powershell_path(), tools_path);
+    let command_line = format!("{} -ExecutionPolicy Bypass -NoExit -File {}/Initialize-Idf.ps1 -IdfId {}", get_powershell_path(), tools_path, idf_id);
 
     let profile_json = json::object! {
         "name": title,


### PR DESCRIPTION
Add support to retrieve information about installed ESP-IDF property based on IDF ID.
Syntax:
```
idf-env config get --property python --idf-id esp-idf-618cf3b908db7b2ed74540bde5ba6605
```
This should be more reliable alternative to filter by `idf-path`.

This feature is necessary to solve:
- https://github.com/espressif/idf-installer/issues/31
- https://github.com/espressif/idf-installer/issues/29
