### PR TITLE
Updated driver paths to our server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idf-env"
-version = "1.2.31"
+version = "1.2.32"
 authors = ["Juraj Michalek <juraj.michalek@espressif.com>"]
 edition = "2018"
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -193,7 +193,7 @@ pub fn download_drivers(
 ) -> std::result::Result<(), clap::Error> {
     if _matches.is_present("silabs") {
         match prepare_package(
-            "https://www.silabs.com/documents/public/software/CP210x_Universal_Windows_Driver.zip"
+            "https://dl.espressif.com/dl/idf-installer/CP210x_Universal_Windows_Driver.zip"
                 .to_string(),
             "cp210x.zip",
             get_driver_path("silabs-2021-05-03".to_string()),
@@ -208,7 +208,7 @@ pub fn download_drivers(
     }
     if _matches.is_present("ftdi") {
         match prepare_package(
-            "https://www.ftdichip.com/Driver/CDM/CDM%20v2.12.28%20WHQL%20Certified.zip".to_string(),
+            "https://dl.espressif.com/dl/idf-installer/CDM_v2.12.28_WHQL_Certified.zip".to_string(),
             "ftdi.zip",
             get_driver_path("ftdi-2021-05-03".to_string()),
         ) {
@@ -237,7 +237,7 @@ pub fn download_drivers(
     }
     if _matches.is_present("wch") {
         match prepare_package(
-            "https://www.wch.cn/downloads/file/314.html".to_string(),
+            "https://dl.espressif.com/dl/idf-installer/CH341SER.ZIP".to_string(),
             "whc-ch343ser.zip",
             get_driver_path("whc-ch343ser-2022-08-02".to_string()),
         ) {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

Because of the [failing pipelines](https://github.com/espressif/idf-installer/actions/runs/11031500135/job/30700340801) of IDF Windows Installer, we have moved the driver source files to our server.

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

* Failing pipeline because of the FTDI driver: https://github.com/espressif/idf-installer/actions/runs/11031500135/job/30700340801